### PR TITLE
Extracting number of qubits from `DefinitionComplex`

### DIFF
--- a/roqoqo-quest/src/backend.rs
+++ b/roqoqo-quest/src/backend.rs
@@ -243,21 +243,13 @@ impl Backend {
                 Operation::PragmaRepeatedMeasurement(o) => {
                     match number_measurements{
                         Some(_) => return Err(RoqoqoBackendError::GenericError{msg: format!("Only one repeated measurement allowed, trying to run repeated measurement for {} but already used for  {:?}", o.readout(), repeated_measurement_readout )}),
-                        None => { 
-                                number_measurements = Some(*o.number_measurements()); 
-                                repeated_measurement_readout = o.readout().clone();  
-                                replace_measurements=Some(0);
-                            }
+                        None => { number_measurements = Some(*o.number_measurements()); repeated_measurement_readout = o.readout().clone(); replace_measurements=Some(0);}
                         }
                 }
                 Operation::PragmaSetNumberOfMeasurements(o) => {
                     match number_measurements{
                         Some(_) => return Err(RoqoqoBackendError::GenericError{msg: format!("Only one repeated measurement allowed, trying to run repeated measurement for {} but already used for  {:?}", o.readout(), repeated_measurement_readout )}),
-                        None => {
-                                number_measurements = Some(*o.number_measurements()); 
-                                repeated_measurement_readout = o.readout().clone(); 
-                                replace_measurements=Some(0);
-                        }
+                        None => {number_measurements = Some(*o.number_measurements()); repeated_measurement_readout = o.readout().clone(); replace_measurements=Some(0);}
                     }
                 }
                 _ => ()

--- a/roqoqo-quest/src/interface/preprocessing.rs
+++ b/roqoqo-quest/src/interface/preprocessing.rs
@@ -40,8 +40,8 @@ pub fn get_number_used_qubits_and_registers(
             }
             Operation::DefinitionComplex(def) => {
                 if *def.is_output() {
-                    // Used bits is given by ceiling of Log2
-                    let bits = u64::BITS - (def.length() - 1).leading_zeros();
+                    // Size of register = 4^(qubits_used)
+                    let bits = (u64::BITS - (def.length() - 1).leading_zeros())/2;
                     registers.insert(def.name().clone(), bits as usize);
                     max_qubit = cmp::max(max_qubit, bits as usize)
                 }
@@ -155,9 +155,9 @@ mod tests {
 
         let (used, reg) = get_number_used_qubits_and_registers(&c.iter().into_iter().collect());
 
-        let cmp_register = HashMap::from([("ro".to_string(), 6 as usize)]);
+        let cmp_register = HashMap::from([("ro".to_string(), 3 as usize)]);
         assert_eq!(cmp_register, reg);
-        assert_eq!(used, 6);
+        assert_eq!(used, 3);
 
         let mut c = Circuit::new();
         c += DefinitionBit::new("ro".to_string(), 2, true);
@@ -168,9 +168,9 @@ mod tests {
 
         let cmp_register = HashMap::from([
             ("ro".to_string(), 2 as usize),
-            ("ri".to_string(), 4 as usize),
+            ("ri".to_string(), 2 as usize),
         ]);
         assert_eq!(cmp_register, reg);
-        assert_eq!(used, 4);
+        assert_eq!(used, 2);
     }
 }

--- a/roqoqo-quest/src/interface/preprocessing.rs
+++ b/roqoqo-quest/src/interface/preprocessing.rs
@@ -41,7 +41,7 @@ pub fn get_number_used_qubits_and_registers(
             Operation::DefinitionComplex(def) => {
                 if *def.is_output() {
                     // Size of register = 4^(qubits_used)
-                    let bits = (u64::BITS - (def.length() - 1).leading_zeros())/2;
+                    let bits = (u64::BITS - (def.length() - 1).leading_zeros()) / 2;
                     registers.insert(def.name().clone(), bits as usize);
                     max_qubit = cmp::max(max_qubit, bits as usize)
                 }

--- a/roqoqo-quest/src/interface/preprocessing.rs
+++ b/roqoqo-quest/src/interface/preprocessing.rs
@@ -22,7 +22,9 @@ pub fn get_number_used_qubits_and_registers(
     let mut registers: HashMap<String, usize> = HashMap::new();
     let mut max_qubit: usize = 0;
     for op in circuit {
-        if let InvolvedQubits::Set(n) = op.involved_qubits() { used_qubits.extend(&n) }
+        if let InvolvedQubits::Set(n) = op.involved_qubits() {
+            used_qubits.extend(&n)
+        }
         match op {
             Operation::DefinitionBit(def) => {
                 if *def.is_output() {

--- a/roqoqo-quest/tests/integration/backend.rs
+++ b/roqoqo-quest/tests/integration/backend.rs
@@ -204,7 +204,7 @@ fn test_running_with_device() {
 #[test]
 fn test_global_phase() {
     let mut circuit = Circuit::new();
-    circuit += DefinitionComplex::new("ro".to_string(), 2, true);
+    circuit += DefinitionComplex::new("ro".to_string(), 4, true);
     circuit += PragmaGlobalPhase::new(0.1.into());
     circuit += PragmaGetStateVector::new("ro".to_string(), None);
     let backend = Backend::new(2);


### PR DESCRIPTION
Length of `DefinitionComplex` = 4^(Number of qubits)