### PR TITLE
DefinitionComplex Length Check

### DIFF
--- a/roqoqo-quest/src/interface/pragma_operations.rs
+++ b/roqoqo-quest/src/interface/pragma_operations.rs
@@ -380,6 +380,13 @@ pub fn execute_pragma_get_density_matrix(
 ) -> Result<(), RoqoqoBackendError> {
     let readout = operation.readout();
     let density_matrix_flattened_row_major = qureg.density_matrix_flattened_row_major()?;
+    let reg_length = complex_registers.get(&readout.clone()).unwrap().len();
+    let density_matrix_length = density_matrix_flattened_row_major.len();
+    if reg_length != density_matrix_length {
+        return Err(RoqoqoBackendError::GenericError {
+            msg: format!("Incorrect density matrix dimensions: {} elements, but the DefinitionComplex register is {} elements long.", reg_length, density_matrix_length),
+        });
+    }
     complex_registers.insert(readout.clone(), density_matrix_flattened_row_major);
     Ok(())
 }


### PR DESCRIPTION
Just a draft that solves the following inconsistency:
```python
from qoqo import Circuit
from qoqo import operations as ops
from qoqo_quest import Backend

number_qubits = 2
test_circuit = Circuit()
test_circuit += ops.DefinitionComplex(name="ro", length=1, is_output=True)
test_circuit += ops.DefinitionComplex(name="ri", length=1, is_output=True)
test_circuit += ops.PauliZ(0)
test_circuit += ops.PauliZ(1)
test_circuit += ops.PragmaGetDensityMatrix(readout="ro", circuit=None)
test_circuit += ops.PragmaGetStateVector(readout="ri", circuit=None)

backend = Backend(number_qubits)
bit_regs, float_regs, complex_regs = backend.run_circuit(test_circuit)
```
this runs fine at the moment, but the length of the DefinitionComplex isn't checked.
With the addition, it now returns an error: `RuntimeError: Running Circuit failed GenericError { msg: "Incorrect density matrix dimensions: 1 elements, but the DefinitionComplex register is 16 elements long." }`
The following code does not return an error:
```python
from qoqo import Circuit
from qoqo import operations as ops
from qoqo_quest import Backend

number_qubits = 2
test_circuit = Circuit()
test_circuit += ops.DefinitionComplex(name="ro", length=4**number_qubits, is_output=True)
test_circuit += ops.DefinitionComplex(name="ri", length=1, is_output=True)
test_circuit += ops.PauliZ(0)
test_circuit += ops.PauliZ(1)
test_circuit += ops.PragmaGetDensityMatrix(readout="ro", circuit=None)
test_circuit += ops.PragmaGetStateVector(readout="ri", circuit=None)

backend = Backend(number_qubits)
bit_regs, float_regs, complex_regs = backend.run_circuit(test_circuit)

print(bit_regs)
print(float_regs)
print(complex_regs)
```
Not implemented yet, but the same would be true for the PragmaGetStateVector too.