### PR TITLE
`sdist` Deploy Fix

### DIFF
--- a/qoqo-quest/pyproject.toml
+++ b/qoqo-quest/pyproject.toml
@@ -18,6 +18,7 @@ compatibility = "manylinux2014"
 skip-auditwheel = false
 strip = true
 profile = "release"
+include = [{ path = "LICENSE", format = "sdist" }]
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
Fixes LICENSE file missing when building the source distribution.

Meaning, this error https://github.com/HQSquantumsimulations/qoqo-quest/actions/runs/13138412268/job/36660373747